### PR TITLE
Update URLs for dlmirrors

### DIFF
--- a/suite/dlmirrors/bookworm
+++ b/suite/dlmirrors/bookworm
@@ -1,22 +1,22 @@
 case $(uname -m) in
 	aarch64|arm64|armv8a|arm64-v8a)
 		if [ "${thirtytwobit:-}" == true ]; then
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm32v7/bookworm/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm32v7/bookworm/oci/blobs/rootfs.tar.gz"
 		else
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm64v8/bookworm/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm64v8/bookworm/oci/blobs/rootfs.tar.gz"
 		fi
 		;;
 	armhf|arm|arm32|armv8l|armv7l)
-		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm32v7/bookworm/rootfs.tar.xz"
+		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm32v7/bookworm/oci/blobs/rootfs.tar.gz"
 		;;
 	i386|i686|x86)
-		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-i386/bookworm/rootfs.tar.xz"
+		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-i386/bookworm/oci/blobs/rootfs.tar.gz"
 		;;
 	amd64|x86_64|x64)
 		if [ "${thirtytwobit:-}" == true ]; then
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm32v7/bookworm/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm32v7/bookworm/oci/blobs/rootfs.tar.gz"
 		else
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-amd64/bookworm/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-amd64/bookworm/oci/blobs/rootfs.tar.gz"
 		fi
 		;;
 esac

--- a/suite/dlmirrors/bullseye
+++ b/suite/dlmirrors/bullseye
@@ -1,22 +1,22 @@
 case $(uname -m) in
 	aarch64|arm64|armv8a|arm64-v8a)
-		if [ ""${thirtytwobit:-}"" == true ]; then
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm32v7/bullseye/rootfs.tar.xz"
+		if [ "${thirtytwobit:-}" == true ]; then
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm32v7/bullseye/oci/blobs/rootfs.tar.gz"
 		else
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm64v8/bullseye/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm64v8/bullseye/oci/blobs/rootfs.tar.gz"
 		fi
 		;;
 	armhf|arm|arm32|armv8l|armv7l)
-		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm32v7/bullseye/rootfs.tar.xz"
+		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm32v7/bullseye/oci/blobs/rootfs.tar.gz"
 		;;
 	i386|i686|x86)
-		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-i386/bullseye/rootfs.tar.xz"
+		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-i386/bullseye/oci/blobs/rootfs.tar.gz"
 		;;
 	amd64|x86_64|x64)
 		if [ "${thirtytwobit:-}" == true ]; then
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-i386/bullseye/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm32v7/bullseye/oci/blobs/rootfs.tar.gz"
 		else
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-amd64/bullseye/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-amd64/bullseye/oci/blobs/rootfs.tar.gz"
 		fi
 		;;
 esac

--- a/suite/dlmirrors/buster
+++ b/suite/dlmirrors/buster
@@ -1,22 +1,22 @@
 case $(uname -m) in
 	aarch64|arm64|armv8a|arm64-v8a)
 		if [ "${thirtytwobit:-}" == true ]; then
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm32v7/buster/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm32v7/buster/oci/blobs/rootfs.tar.gz"
 		else
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm64v8/buster/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm64v8/buster/oci/blobs/rootfs.tar.gz"
 		fi
 		;;
 	armhf|arm|arm32|armv8l|armv7l)
-		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm32v7/buster/rootfs.tar.xz"
+		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm32v7/buster/oci/blobs/rootfs.tar.gz"
 		;;
 	i386|i686|x86)
-		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-i386/buster/rootfs.tar.xz"
+		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-i386/buster/oci/blobs/rootfs.tar.gz"
 		;;
 	amd64|x86_64|x64)
 		if [ "${thirtytwobit:-}" == true ]; then
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm32v7/buster/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm32v7/buster/oci/blobs/rootfs.tar.gz"
 		else
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-amd64/buster/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-amd64/buster/oci/blobs/rootfs.tar.gz"
 		fi
 		;;
 esac

--- a/suite/dlmirrors/sid
+++ b/suite/dlmirrors/sid
@@ -1,22 +1,22 @@
 case $(uname -m) in
 	aarch64|arm64|armv8a|arm64-v8a)
 		if [ "${thirtytwobit:-}" == true ]; then
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm32v7/sid/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm32v7/sid/oci/blobs/rootfs.tar.gz"
 		else
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm64v8/sid/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm64v8/sid/oci/blobs/rootfs.tar.gz"
 		fi
 		;;
 	armhf|arm|arm32|armv8l|armv7l)
-		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm32v7/sid/rootfs.tar.xz"
+		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm32v7/sid/oci/blobs/rootfs.tar.gz"
 		;;
 	i386|i686|x86)
-		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-i386/sid/rootfs.tar.xz"
+		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-i386/sid/oci/blobs/rootfs.tar.gz"
 		;;
 	amd64|x86_64|x64)
 		if [ "${thirtytwobit:-}" == true ]; then
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm32v7/sid/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm32v7/sid/oci/blobs/rootfs.tar.gz"
 		else
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-amd64/sid/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-amd64/sid/oci/blobs/rootfs.tar.gz"
 		fi
 		;;
 esac

--- a/suite/dlmirrors/testing
+++ b/suite/dlmirrors/testing
@@ -1,22 +1,22 @@
 case $(uname -m) in
 	aarch64|arm64|armv8a|arm64-v8a)
 		if [ "${thirtytwobit:-}" == true ]; then
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm32v7/testing/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm32v7/testing/oci/blobs/rootfs.tar.gz"
 		else
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm64v8/testing/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm64v8/testing/oci/blobs/rootfs.tar.gz"
 		fi
 		;;
 	armhf|arm|arm32|armv8l|armv7l)
-		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm32v7/testing/rootfs.tar.xz"
+		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm32v7/testing/oci/blobs/rootfs.tar.gz"
 		;;
 	i386|i686|x86)
-		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-i386/testing/rootfs.tar.xz"
+		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-i386/testing/oci/blobs/rootfs.tar.gz"
 		;;
 	amd64|x86_64|x64)
 		if [ "${thirtytwobit:-}" == true ]; then
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm32v7/testing/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm32v7/testing/oci/blobs/rootfs.tar.gz"
 		else
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-amd64/testing/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-amd64/testing/oci/blobs/rootfs.tar.gz"
 		fi
 		;;
 esac

--- a/suite/dlmirrors/trixie
+++ b/suite/dlmirrors/trixie
@@ -1,22 +1,22 @@
 case $(uname -m) in
 	aarch64|arm64|armv8a|arm64-v8a)
 		if [ "${thirtytwobit:-}" == true ]; then
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm32v7/trixie/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm32v7/trixie/oci/blobs/rootfs.tar.gz"
 		else
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm64v8/trixie/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm64v8/trixie/oci/blobs/rootfs.tar.gz"
 		fi
 		;;
 	armhf|arm|arm32|armv8l|armv7l)
-		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm32v7/trixie/rootfs.tar.xz"
+		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm32v7/trixie/oci/blobs/rootfs.tar.gz"
 		;;
 	i386|i686|x86)
-		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-i386/trixie/rootfs.tar.xz"
+		curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-i386/trixie/oci/blobs/rootfs.tar.gz"
 		;;
 	amd64|x86_64|x64)
 		if [ "${thirtytwobit:-}" == true ]; then
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-arm32v7/trixie/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-arm32v7/trixie/oci/blobs/rootfs.tar.gz"
 		else
-			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/dist-amd64/trixie/rootfs.tar.xz"
+			curl_download_link="https://github.com/debuerreotype/docker-debian-artifacts/raw/refs/heads/dist-amd64/trixie/oci/blobs/rootfs.tar.gz"
 		fi
 		;;
 esac


### PR DESCRIPTION
Fixes #2
Ongoing testing... appears this repo changed its file structure now

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zavocc/debdroid/pull/3?shareId=944d82e4-b386-4bcf-9e76-08db75f70068).